### PR TITLE
Problems fixed for scroll bar accessibility issue

### DIFF
--- a/zombies-app/css/styles.css
+++ b/zombies-app/css/styles.css
@@ -244,7 +244,8 @@ body.dark-theme .blood {
 	border-bottom: 4px solid var(--kimberly);
 	transform: rotate(45deg);
 	animation: 3s arrow infinite ease;
-
+	background-color: transparent;
+	text-decoration: none;
 }
 
 .arrowUp {
@@ -262,6 +263,7 @@ body.dark-theme .blood {
 .arrow:hover+.arrowhovertext {
 	display: block;
 }
+
 
 /* Content */
 

--- a/zombies-app/css/styles.css
+++ b/zombies-app/css/styles.css
@@ -333,6 +333,10 @@ body.dark-theme p a:active {
 	text-decoration: none;
 }
 
+.flex-container>a:focus {
+	outline: 5px;
+}
+
 .flex-container>a:hover {
 	box-shadow: 0 8px 16px 0 var(--dark-mode);
 }

--- a/zombies-app/index.html
+++ b/zombies-app/index.html
@@ -22,7 +22,7 @@
 	<div class="hide-if-loading">
 
 		<header>
-			<a class="skip-to-content-link" href="#about">Skip to Content</a>
+			<a class="skip-to-content-link" href="#container">Skip to Content</a>
 			<!-- Mobile Nav -->
 			<div class="hamburg">
 				<button class="menu" id="ham-menu"></button>
@@ -49,8 +49,6 @@
 
 		<!-- Cards -->
 		<div class="container" id="container">
-			<div id="arrow" tabindex="0" class="arrow" role="scrollbar" aria-label="arrow scroll bar"></div>
-			<div class="arrowhovertext">Click here to scroll</div>
 			<h1 class="title blood">Zombies With #VetsWhoCode</h1>
 			<div class="flex-container" id="cards">
 

--- a/zombies-app/index.html
+++ b/zombies-app/index.html
@@ -50,6 +50,8 @@
 		<!-- Cards -->
 		<div class="container" id="container">
 			<h1 class="title blood">Zombies With #VetsWhoCode</h1>
+			<div id="arrow" class="arrow" role="scrollbar" aria-label="arrow scroll bar"></div>								
+			<div class="arrowhovertext">Click here to scroll</div>
 			<div class="flex-container" id="cards">
 
 				<a href="#" onclick="zombieprompt()" class="radar" id="radar-div">


### PR DESCRIPTION
<Problems>
1. The attempt to link “skip to content” feature to the arrow feature does not work. It’s not properly linked. It doesn’t function.
2. This attempt in the first place rejects the original purpose of the “skip to content” 
3. The arrow scroll bar behaves similar to the button but it’s actually div, so it doesn’t have any of the native accessibility features of the button. So this is an example of bad semantic html.

<Solution>
1. Go back to the original commit of skip to content directing to the actual content
2. Remove the div