### PR TITLE
adjusted site map links

### DIFF
--- a/javascript-job-search-mvp/css/styles.css
+++ b/javascript-job-search-mvp/css/styles.css
@@ -304,6 +304,7 @@ footer {
 .site-link {
 	color: white !important;
 	margin-bottom: 10px;
+	margin-left: 5px;
 }
 
 .site-link:hover {

--- a/javascript-job-search-mvp/index.html
+++ b/javascript-job-search-mvp/index.html
@@ -174,32 +174,32 @@
 						<div class="col-md-6">
 							<ul>
 								<li class="footer-li"><i class="far fa-circle fa-xs footer-icon"></i><a class="site-link"
-										href="https://vetswhocode.io/"> HOME</a></li>
+										href="https://vetswhocode.io/">HOME</a></li>
 								<li class="footer-li"><i class="far fa-circle fa-xs footer-icon"></i><a class="site-link"
-										href="https://vetswhocode.io/about"> ABOUT</a></li>
+										href="https://vetswhocode.io/about">ABOUT</a></li>
 								<li class="footer-li"><i class="far fa-circle fa-xs footer-icon"></i><a class="site-link"
-										href="https://vetswhocode.io/board"> BOARD</a></li>
+										href="https://vetswhocode.io/board">BOARD</a></li>
 								<li class="footer-li"><i class="far fa-circle fa-xs footer-icon"></i><a class="site-link"
-										href="https://vetswhocode.io/syllabus"> SYLLABUS</a></li>
+										href="https://vetswhocode.io/syllabus">SYLLABUS</a></li>
 								<li class="footer-li"><i class="far fa-circle fa-xs footer-icon"></i><a class="site-link"
-										href="https://vetswhocode.io/testimonials"> TESTIMONIALS</a>
+										href="https://vetswhocode.io/testimonials">TESTIMONIALS</a>
 								</li>
-								<li class="footer-li"><i class="far fa-circle fa-xs footer-icon"></i><a class="site-link" href=""> JOB
+								<li class="footer-li"><i class="far fa-circle fa-xs footer-icon"></i><a class="site-link" href="">JOB
 										SEARCH</a></li>
 							</ul>
 						</div>
 						<div class="col-md-6">
 							<ul>
 								<li class="footer-li"><i class="far fa-circle fa-xs footer-icon"></i><a class="site-link"
-										href="https://vetswhocode.io/mentor"> MENTOR</a></li>
+										href="https://vetswhocode.io/mentor">MENTOR</a></li>
 								<li class="footer-li"><i class="far fa-circle fa-xs footer-icon"></i><a class="site-link"
-										href="https://vetswhocode.io/apply"> APPLY</a></li>
+										href="https://vetswhocode.io/apply">APPLY</a></li>
 								<li class="footer-li"><i class="far fa-circle fa-xs footer-icon"></i><a class="site-link"
-										href="https://vetswhocode.io/donate"> DONATE</a></li>
+										href="https://vetswhocode.io/donate">DONATE</a></li>
 								<li class="footer-li"><i class="far fa-circle fa-xs footer-icon"></i><a class="site-link"
-										href="https://vetswhocode.io/contact"> CONTACT US</a></li>
+										href="https://vetswhocode.io/contact">CONTACT US</a></li>
 								<li class="footer-li"><i class="far fa-circle fa-xs footer-icon"></i><a class="site-link"
-										href="https://vetswhocode.io/blog"> BLOG</a></li>
+										href="https://vetswhocode.io/blog">BLOG</a></li>
 							</ul>
 						</div>
 					</div>


### PR DESCRIPTION
Instead of putting a space before the link names, I used some margin to separate the links from the circle icons. This fixes the extra space before the link names when you hover over them. 

<img width="151" alt="Screen Shot 2021-04-11 at 10 10 33 PM" src="https://user-images.githubusercontent.com/16889593/114332046-65d3df00-9b13-11eb-9e5b-ff23063a2aed.png">

to this:

<img width="178" alt="Screen Shot 2021-04-11 at 10 15 58 PM" src="https://user-images.githubusercontent.com/16889593/114332149-9b78c800-9b13-11eb-91c7-2afff07791f1.png">

